### PR TITLE
Add spec for filename

### DIFF
--- a/ext-wp.md
+++ b/ext-wp.md
@@ -91,6 +91,13 @@ Additionally, the following are recognised as aliases:
 
 All section content MAY contain HTML
 
+#### filename
+
+The `filename` property specifies the root folder and file name for the package.
+
+The filename MUST be a string containing only alphanumeric characters, dashes, or underscores. Optionally the filename may contain a period or a forward slash. The file MUST start with an alphabetic character.
+
+The filename MUST be a string.
 
 ### Release Document
 

--- a/specification.md
+++ b/specification.md
@@ -212,7 +212,6 @@ The following properties are defined for the metadata document:
 | releases    | yes       | A list of [Releases](#release-document)                             |
 | slug        | no        | A string that conforms to the rules of [slug](#property-slug)       |
 | name        | no        | A string.                                                           |
-| filename    | no        | A string that conforms to the rules of [filename](#property-file)   |
 | description | no        | A string.                                                           |
 | keywords    | no        | A list of strings.                                                  |
 | sections    | no        | A map that conforms to the rules of [sections](#property-sections)  |
@@ -328,15 +327,6 @@ Clients SHOULD use the slug for file or directory names used during installation
 ### name
 
 The `name` property specifies a human-readable name for the package, which the client may display in index or list pages.
-
-
-### filename
-
-The `filename` property specifies the root folder and file name for the package.
-
-The filename MUST be a string containing only alphanumeric characters, dashes, or underscores. Optionally the filename may contain a period or a forward slash. The file MUST start with an alphabetic character.
-
-The filename MUST be a string.
 
 
 ### description

--- a/specification.md
+++ b/specification.md
@@ -212,6 +212,7 @@ The following properties are defined for the metadata document:
 | releases    | yes       | A list of [Releases](#release-document)                             |
 | slug        | no        | A string that conforms to the rules of [slug](#property-slug)       |
 | name        | no        | A string.                                                           |
+| file        | no        | A string that conforms to the rules of [file](#property-file)       |
 | description | no        | A string.                                                           |
 | keywords    | no        | A list of strings.                                                  |
 | sections    | no        | A map that conforms to the rules of [sections](#property-sections)  |
@@ -328,7 +329,14 @@ Clients SHOULD use the slug for file or directory names used during installation
 
 The `name` property specifies a human-readable name for the package, which the client may display in index or list pages.
 
-The name MUST be a string.
+
+### file
+
+The `file` property specifies the file name for the package as a `slug/plugin.php` for a plugin, or just the `slug` for a theme. The client in WordPress will utilize this information when the package requires updating. The file is used as a key in the update transient associative array.
+
+The file MUST be a string containing only alphanumeric characters, dashes, or underscores. The file MUST start with an alphabetic character.
+
+The file MUST be a string.
 
 
 ### description

--- a/specification.md
+++ b/specification.md
@@ -332,7 +332,7 @@ The `name` property specifies a human-readable name for the package, which the c
 
 ### file
 
-The `file` property specifies the file name for the package as a `slug/plugin.php` for a plugin, or just the `slug` for a theme. The client in WordPress will utilize this information when the package requires updating. The file is used as a key in the update transient associative array.
+The `file` property specifies the file name for the package.
 
 The file MUST be a string containing only alphanumeric characters, dashes, or underscores. The file MUST start with an alphabetic character.
 

--- a/specification.md
+++ b/specification.md
@@ -332,7 +332,7 @@ The `name` property specifies a human-readable name for the package, which the c
 
 ### filename
 
-The `filename` property specifies the file name for the package.
+The `filename` property specifies the root folder and file name for the package.
 
 The filename MUST be a string containing only alphanumeric characters, dashes, or underscores. Optionally the filename may contain a period or a forward slash. The file MUST start with an alphabetic character.
 

--- a/specification.md
+++ b/specification.md
@@ -328,6 +328,8 @@ Clients SHOULD use the slug for file or directory names used during installation
 
 The `name` property specifies a human-readable name for the package, which the client may display in index or list pages.
 
+The name MUST be a string.
+
 
 ### description
 

--- a/specification.md
+++ b/specification.md
@@ -212,7 +212,7 @@ The following properties are defined for the metadata document:
 | releases    | yes       | A list of [Releases](#release-document)                             |
 | slug        | no        | A string that conforms to the rules of [slug](#property-slug)       |
 | name        | no        | A string.                                                           |
-| file        | no        | A string that conforms to the rules of [file](#property-file)       |
+| filename    | no        | A string that conforms to the rules of [filename](#property-file)   |
 | description | no        | A string.                                                           |
 | keywords    | no        | A list of strings.                                                  |
 | sections    | no        | A map that conforms to the rules of [sections](#property-sections)  |
@@ -330,13 +330,13 @@ Clients SHOULD use the slug for file or directory names used during installation
 The `name` property specifies a human-readable name for the package, which the client may display in index or list pages.
 
 
-### file
+### filename
 
-The `file` property specifies the file name for the package.
+The `filename` property specifies the file name for the package.
 
-The file MUST be a string containing only alphanumeric characters, dashes, or underscores. The file MUST start with an alphabetic character.
+The filename MUST be a string containing only alphanumeric characters, dashes, or underscores. Optionally the filename may contain a period or a forward slash. The file MUST start with an alphabetic character.
 
-The file MUST be a string.
+The filename MUST be a string.
 
 
 ### description


### PR DESCRIPTION
Adds a spec for the addition of `file` to the list of downloadable data. `file` is used as an associative array key in the update transients.

There is no other way to easily obtain the main plugin file in a plugin.