### PR TITLE
Allow the leading character of a slug to be alphanumeric

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -313,10 +313,10 @@ The items of the list MUST be objects, conforming to the [Release Document](#rel
 
 The `slug` property specifies the desired "slug" for the package, which the client may use for filenames or directory names when installing the package.
 
-The slug MUST be a string containing only alphanumeric characters, dashes, or underscores. The slug MUST start with an alphabetic character.
+The slug MUST be a string containing only alphanumeric characters, dashes, or underscores. The slug MUST start with an alphanumeric character.
 
 ```
-slug  = ALPHA *(ALPHA / DIGIT / "-" / "_")
+slug  = (ALPHA / DIGIT) *(ALPHA / DIGIT / "-" / "_")
 ```
 
 Clients SHOULD validate the slug against these rules. If a slug does not validate, clients MAY strip invalid characters to form a valid slug, or ignore the slug entirely.


### PR DESCRIPTION
The specification currently constrains the first character of a plugin or theme slug to an alphabetic character. This is not a valid or worthwhile constraint because there are plenty of plugins that have a numeric first character (for example https://wordpress.org/plugins/301-redirects/ and https://wordpress.org/plugins/404-solution/).

This change adjusts the description and corresponding ABNF in the spec to allow any alphanumeric character at the beginning of a slug.