### PR TITLE
Remove arbitrary 5-keyword limit from core spec

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -344,7 +344,7 @@ The description SHOULD be written in plain text, and clients MUST escape any spe
 
 The `keywords` property specifies keywords to assist users in searching for packages.
 
-Keywords MUST be a list, represented as a JSON Array. The list SHOULD NOT contain more than 5 items. Clients MAY truncate the list to 5 items.
+Keywords MUST be a list, represented as a JSON Array.
 
 Each item of the array MUST be a string.
 


### PR DESCRIPTION
## Summary
- Removes the `SHOULD NOT contain more than 5 items` and `Clients MAY truncate the list to 5 items` language from the `keywords` property
- The 5-keyword limit is a WordPress.org convention carried over into the core spec, but other ecosystems (TYPO3, Shopify, VS Code Marketplace) have no such constraint
- Individual platform extensions can still impose their own limits if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)