### PR TITLE
Fix test data to conform to JSON schema

### DIFF
--- a/test-data/did_plc_afjf7gsjzsqmgc7dlhb553mv.json
+++ b/test-data/did_plc_afjf7gsjzsqmgc7dlhb553mv.json
@@ -40,7 +40,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -83,7 +83,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -126,7 +126,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -169,7 +169,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -212,7 +212,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -255,7 +255,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -298,7 +298,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -341,7 +341,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -384,7 +384,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -427,7 +427,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -470,7 +470,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -513,7 +513,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -556,7 +556,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -599,7 +599,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -642,7 +642,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -685,7 +685,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -728,7 +728,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -771,7 +771,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -814,7 +814,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -857,7 +857,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -900,7 +900,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -943,7 +943,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -986,7 +986,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -1029,7 +1029,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -1072,7 +1072,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -1115,7 +1115,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -1158,7 +1158,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -1201,7 +1201,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -1244,7 +1244,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {
@@ -1287,7 +1287,7 @@
             "suggests": {
                 "env:wp": ">=6.9.3"
             },
-            "provides": [],
+            "provides": {},
             "artifacts": {
                 "banner": [
                     {

--- a/test-data/did_plc_m5tfrwxd3btacxlstcvop2ib.json
+++ b/test-data/did_plc_m5tfrwxd3btacxlstcvop2ib.json
@@ -13,7 +13,11 @@
     }
   ],
   "license": "GPL v3 or later",
-  "security": [],
+  "security": [
+    {
+      "url": "https://github.com/ProgressPlanner/pp-glossary/security/advisories"
+    }
+  ],
   "keywords": [
     "glossary",
     "definitions",
@@ -37,7 +41,7 @@
       "suggests": {
         "env:wp": ">=6.9.3"
       },
-      "provides": [],
+      "provides": {},
       "artifacts": {
         "icon": [
           {
@@ -66,7 +70,7 @@
       "suggests": {
         "env:wp": ">=6.9.3"
       },
-      "provides": [],
+      "provides": {},
       "artifacts": {
         "icon": [
           {


### PR DESCRIPTION
## Summary

- Change `provides` from empty array `[]` to empty object `{}` in both test data files — the spec requires `provides` to be a map (JSON Object), not an array.
- Add a security contact to `did_plc_m5tfrwxd3btacxlstcvop2ib.json` — the spec requires at least one security contact entry.

These fixes resolve the CI failures visible in #63 and other PRs.

## Test plan

- [x] `npm test` passes locally with both files reported as valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)