### PR TITLE
clients MUST NOT install packages with unrecognized types

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -240,7 +240,11 @@ This property MUST be a valid string. The property SHOULD use a type defined in 
 
 Custom or non-standard types SHOULD be prefixed with `x-` to indicate they are non-standard.
 
-Clients SHOULD refuse to process types which they do not have a semantic understanding of.
+Clients MUST NOT install packages with a `type` they do not have a semantic understanding of. When installation of a Package with an unknown `type` is attempted, clients MUST surface an error message.
+
+Example:
+
+> Could not install: unsupported package ecosystem.
 
 [type-registry]: ./registry.md#package-types
 


### PR DESCRIPTION
SHOULD is insufficient here: Package types gate the entire client processing path: clients processing an unrecognized type can't meaningfully verify the protocol extension requirements for the package type, so proceeding with the install could lead to a broken installation or sidestep a security requirement.