### PR TITLE
Deletion & Tombstone Semantics + version immutability updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.claude
+!CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+This is the **specification repository** for the FAIR (Federated and Independent Repositories) Package Management Protocol — a decentralized package management system built for the WordPress ecosystem. The repo contains:
+
+- The core protocol specification (`specification.md`)
+- Extension specs (`ext-*.md`, `registry.md`, `spec-labeling.md`)
+- Documentation for vendors, implementers, and moderators (`docs/`)
+- A JSON Schema for the FAIR Metadata Document (`schemas/metadata.schema.json`)
+- Test data validating that schema (`test-data/*.json`)
+
+There is no application code. All "code" is the JSON schema and the validation test script.
+
+## Running tests
+
+```bash
+npm test
+```
+
+This runs `scripts/test.sh`, which validates every `test-data/*.json` file against `schemas/metadata.schema.json` using `ajv-cli` with JSON Schema draft 2020-12.
+
+To validate a single file:
+```bash
+./node_modules/.bin/ajv validate --spec=draft2020 --strict --strict-tuples=false -c ajv-formats -s schemas/metadata.schema.json -d test-data/<file>.json
+```
+
+## Key concepts
+
+- **DID** — Each package has a W3C Decentralized Identifier as its globally-unique ID. The DID resolves to a DID Document that points to the package's repository and signing keys.
+- **Repository** — A server that hosts package metadata and binaries. Vendors choose their own; the DID points to it.
+- **Aggregator** — A discovery service that indexes many repositories (like a search engine for packages).
+- **Metadata Document** — The primary data structure defined in `schemas/metadata.schema.json`. It includes package identity, authors, license, and a list of releases each containing versioned artifacts.
+
+## Schema structure
+
+`schemas/metadata.schema.json` defines the Metadata Document. Key top-level required fields: `@context`, `id` (DID), `type`, `license`, `authors`, `releases`. Each release has a `version` and `artifacts` map; artifacts have optional `url`, `signature`, `checksum`, and `requires-auth`. Dependencies use `requires`/`suggests` with DID or `env:*` keys.
+
+## Contributing
+
+This repo is managed by the FAIR Working Group. The TSC repo (`github.com/fairpm/tsc`) has contributing guidelines. All documentation is CC BY 4.0.

--- a/specification.md
+++ b/specification.md
@@ -793,17 +793,19 @@ Publishers may remove Packages or releases from their Repositories. This section
 
 When a Repository no longer serves a previously-indexed Package, the Package is considered deleted.
 
-Aggregators SHOULD retain an internal tombstone record for the Package DID. This tombstone MUST NOT be served in search results and the deleted Package MUST NOT be installable. Direct lookups by DID SHOULD return an explicit `deleted` response (HTTP `410 Gone`) rather than `404 Not Found`.
+Repositories SHOULD retain an internal tombstone record for the Package DID. This tombstone MUST NOT be served in search results and the deleted Package MUST NOT be installable. Direct lookups by DID SHOULD return an explicit `deleted` response (HTTP `410 Gone`) rather than `404 Not Found`.
 
-Since removal from a site is an explicit user action, Package deletion MUST NOT cause uninstallation.
+Since removal from a site is an explicit user action, Package deletion MUST NOT cause uninstallation by the Client.
 
 ### Release deletion
 
 When a specific release record is removed from a Repository, the release is considered deleted.
 
-Aggregators MUST exclude deleted releases from release lists. The latest-release selection algorithm MUST skip deleted releases when determining the current version, as deleted releases MUST NOT be installable. 
+Repositories MUST exclude deleted releases from release lists. The latest-release selection algorithm MUST skip deleted releases when determining the current version, as deleted releases MUST NOT be installable.
 
-Aggregators that mirror artifacts SHOULD remove the mirrored artifact bytes for deleted releases from their object stores. The tombstone record SHOULD be retained.
+Repositories that mirror artifacts SHOULD remove the mirrored artifact bytes for deleted releases from their object stores. The tombstone record SHOULD be retained.
+
+Release deletion MUST NOT cause uninstallation by the Client.
 
 ### Deletion is distinct from version immutability
 

--- a/specification.md
+++ b/specification.md
@@ -441,7 +441,11 @@ The build metadata MUST be ignored when determining version precedence.
 
 #### Version immutability
 
-A Repository MUST NOT modify or replace artifacts or metadata of a published release. The first release record created for a package version MUST be treated as the canonical record. Aggregators that index release records MUST ignore any record for a version that has already been indexed for the same package DID. On update checks, if a Repository serves a release for a previously-installed version, Clients MUST reject the response and MUST alert the user.
+A repository MUST NOT modify or replace the artifacts or metadata of a published release for a given version. The first release record created for a version under a given package DID is the canonical record.
+
+Clients MUST retain the `checksum` value of installed releases. On update checks, if a repository serves a release for a previously-installed version with a different `checksum`, clients MUST reject the response and MUST alert the user.
+
+Aggregators that index release records MUST ignore any record for a version that has already been indexed for the same package DID. The earlier record is canonical; the later record is invalid and MUST be treated as if it were not present.
 
 ### artifacts
 

--- a/specification.md
+++ b/specification.md
@@ -785,6 +785,31 @@ Clients SHOULD only use trusted external caches, such as those provided by the s
 Clients MUST NOT use an external cache for [Resolving DIDs](#resolving-dids), but MAY use an internal cache for this data. DID resolution MUST NOT be cached for more than 24 hours.
 
 
+## Deletion & Tombstone Semantics
+
+Publishers may remove Packages or releases from their Repositories. This section defines the expected behavior of Clients and Aggregators when this occurs.
+
+### Package deletion
+
+When a Repository no longer serves a previously-indexed Package, the Package is considered deleted.
+
+Aggregators SHOULD retain an internal tombstone record for the Package DID. This tombstone MUST NOT be served in search results and the deleted Package MUST NOT be installable. Direct lookups by DID SHOULD return an explicit `deleted` response (HTTP `410 Gone`) rather than `404 Not Found`.
+
+Since removal from a site is an explicit user action, Package deletion MUST NOT cause uninstallation.
+
+### Release deletion
+
+When a specific release record is removed from a Repository, the release is considered deleted.
+
+Aggregators MUST exclude deleted releases from release lists. The latest-release selection algorithm MUST skip deleted releases when determining the current version, as deleted releases MUST NOT be installable. 
+
+Aggregators that mirror artifacts SHOULD remove the mirrored artifact bytes for deleted releases from their object stores. The tombstone record SHOULD be retained.
+
+### Deletion is distinct from version immutability
+
+Deletion removes a release from distribution. A Publisher removing a release is explicitly permitted; a Publisher releasing a new artifact in place of an existing version is not (see [Version immutability](#version-immutability)). A deleted release MUST NOT be republished under the same version number, for which a tombstone record is retained.
+
+
 ## JSON-LD Contexts
 
 The following JSON-LD contexts are registered by this specification.


### PR DESCRIPTION
## Summary

- Adds new **Deletion & Tombstone Semantics** section covering package deletion, release deletion, and how deletion differs from version immutability
- Expands **Version immutability** rule to clarify checksum retention by clients and aggregator behavior
- Fixes wording in deletion section: corrects "Aggregators" → "Repositories" where appropriate, adds explicit "Release deletion MUST NOT cause uninstallation by the Client" rule
- Updates `.gitignore` to exclude `.claude/` while keeping `CLAUDE.md` tracked
- Adds `CLAUDE.md` for Claude Code guidance

## Test plan

- [ ] Review deletion semantics section for correctness and consistency with existing spec language
- [ ] Confirm version immutability changes align with intended client/aggregator behavior
- [ ] Run `npm test` to validate schema and test data are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)